### PR TITLE
refactor: completion command to use context writer for output

### DIFF
--- a/internal/command/completion/bash/bash.go
+++ b/internal/command/completion/bash/bash.go
@@ -2,7 +2,6 @@ package bash
 
 import (
 	"html/template"
-	"os"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -41,7 +40,7 @@ func NewCommands(cfg *config.Config, flags []cli.Flag) *cli.Command {
 			if err != nil {
 				return err
 			}
-			if err = t.Execute(os.Stdout, ctx.App.Name); err != nil {
+			if err = t.Execute(ctx.App.Writer, ctx.App.Name); err != nil {
 				return err
 			}
 			return nil

--- a/internal/command/completion/fish/fish.go
+++ b/internal/command/completion/fish/fish.go
@@ -18,7 +18,7 @@ func NewCommands(cfg *config.Config, flags []cli.Flag) *cli.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Println(fish)
+			fmt.Fprint(ctx.App.Writer, fish)
 			return nil
 		},
 	}

--- a/internal/command/completion/powershell/powershell.go
+++ b/internal/command/completion/powershell/powershell.go
@@ -27,7 +27,7 @@ func NewCommands(cfg *config.Config, flags []cli.Flag) *cli.Command {
 		Usage:    "powershell completion",
 		HideHelp: true,
 		Action: func(ctx *cli.Context) error {
-			fmt.Println(strings.TrimSpace(powershellCompletion))
+			fmt.Fprint(ctx.App.Writer, strings.TrimSpace(powershellCompletion)+"\n")
 			return nil
 		},
 	}

--- a/internal/command/completion/zsh/zsh.go
+++ b/internal/command/completion/zsh/zsh.go
@@ -2,7 +2,6 @@ package zsh
 
 import (
 	"html/template"
-	"os"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -46,7 +45,7 @@ func NewCommands(cfg *config.Config, flags []cli.Flag) *cli.Command {
 			if err != nil {
 				return err
 			}
-			if err = t.Execute(os.Stdout, ctx.App.Name); err != nil {
+			if err = t.Execute(ctx.App.Writer, ctx.App.Name); err != nil {
 				return err
 			}
 			return nil


### PR DESCRIPTION
- Remove unused import statements in completion files
- Update template execution to use `ctx.App.Writer` instead of `os.Stdout`
- Change `fmt.Println` to `fmt.Fprint` in Powershell completion file
- Modify `Action` function in Fish completion file to use `fmt.Fprint()` instead of `fmt.Println()`
