### PR TITLE
test: Add tests for completion commands in multiple shells

### DIFF
--- a/internal/command/completion/bash/bash_test.go
+++ b/internal/command/completion/bash/bash_test.go
@@ -1,0 +1,35 @@
+package bash_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/takumin/boilerplate-golang-cli/internal/command/completion/bash"
+	"github.com/takumin/boilerplate-golang-cli/internal/config"
+)
+
+func TestNewCommands(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	app := &cli.App{Writer: &stdout, ErrWriter: &stderr}
+	app.Setup()
+	ctx := cli.NewContext(app, nil, nil)
+	cmd := bash.NewCommands(config.NewConfig(), []cli.Flag{})
+
+	if cmd.Name != "bash" {
+		t.Errorf("expected command name to be 'bash', but got '%s'", cmd.Name)
+	}
+
+	if cmd.Usage != "bash completion" {
+		t.Errorf("expected command usage to be 'bash completion', but got '%s'", cmd.Usage)
+	}
+
+	if err := cmd.Run(ctx); err != nil {
+		t.Errorf("falied to run bash completion: %v\nstdout: %v\n stderr: %v", err, stdout, stderr)
+	}
+
+	if stdout.Len() == 0 {
+		t.Error("expected bash completion output to be non-empty, but got empty")
+	}
+}

--- a/internal/command/completion/completion_test.go
+++ b/internal/command/completion/completion_test.go
@@ -1,0 +1,30 @@
+package completion_test
+
+import (
+	"testing"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/takumin/boilerplate-golang-cli/internal/command/completion"
+	"github.com/takumin/boilerplate-golang-cli/internal/config"
+)
+
+func TestNewCommands(t *testing.T) {
+	cfg := config.NewConfig()
+	flags := []cli.Flag{}
+	cmd := completion.NewCommands(cfg, flags)
+
+	if cmd.Name != "completion" {
+		t.Errorf("expected command name to be 'completion', but got '%s'", cmd.Name)
+	}
+
+	if cmd.Usage != "command completion" {
+		t.Errorf("expected command usage to be 'command completion', but got '%s'", cmd.Usage)
+	}
+
+	for _, subcmd := range cmd.Subcommands {
+		if subcmd == nil {
+			t.Errorf("expected subcommand to not be nil")
+		}
+	}
+}

--- a/internal/command/completion/fish/fish_test.go
+++ b/internal/command/completion/fish/fish_test.go
@@ -1,0 +1,35 @@
+package fish_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/takumin/boilerplate-golang-cli/internal/command/completion/fish"
+	"github.com/takumin/boilerplate-golang-cli/internal/config"
+)
+
+func TestNewCommands(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	app := &cli.App{Writer: &stdout, ErrWriter: &stderr}
+	app.Setup()
+	ctx := cli.NewContext(app, nil, nil)
+	cmd := fish.NewCommands(config.NewConfig(), []cli.Flag{})
+
+	if cmd.Name != "fish" {
+		t.Errorf("expected command name to be 'fish', but got '%s'", cmd.Name)
+	}
+
+	if cmd.Usage != "fish completion" {
+		t.Errorf("expected command usage to be 'fish completion', but got '%s'", cmd.Usage)
+	}
+
+	if err := cmd.Run(ctx); err != nil {
+		t.Errorf("falied to run fish completion: %v\nstdout: %v\n stderr: %v", err, stdout, stderr)
+	}
+
+	if stdout.Len() == 0 {
+		t.Error("expected fish completion output to be non-empty, but got empty")
+	}
+}

--- a/internal/command/completion/powershell/powershell_test.go
+++ b/internal/command/completion/powershell/powershell_test.go
@@ -1,0 +1,35 @@
+package powershell_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/takumin/boilerplate-golang-cli/internal/command/completion/powershell"
+	"github.com/takumin/boilerplate-golang-cli/internal/config"
+)
+
+func TestNewCommands(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	app := &cli.App{Writer: &stdout, ErrWriter: &stderr}
+	app.Setup()
+	ctx := cli.NewContext(app, nil, nil)
+	cmd := powershell.NewCommands(config.NewConfig(), []cli.Flag{})
+
+	if cmd.Name != "powershell" {
+		t.Errorf("expected command name to be 'powershell', but got '%s'", cmd.Name)
+	}
+
+	if cmd.Usage != "powershell completion" {
+		t.Errorf("expected command usage to be 'powershell completion', but got '%s'", cmd.Usage)
+	}
+
+	if err := cmd.Run(ctx); err != nil {
+		t.Errorf("falied to run powershell completion: %v\nstdout: %v\n stderr: %v", err, stdout, stderr)
+	}
+
+	if stdout.Len() == 0 {
+		t.Error("expected powershell completion output to be non-empty, but got empty")
+	}
+}

--- a/internal/command/completion/zsh/zsh_test.go
+++ b/internal/command/completion/zsh/zsh_test.go
@@ -1,0 +1,35 @@
+package zsh_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/takumin/boilerplate-golang-cli/internal/command/completion/zsh"
+	"github.com/takumin/boilerplate-golang-cli/internal/config"
+)
+
+func TestNewCommands(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	app := &cli.App{Writer: &stdout, ErrWriter: &stderr}
+	app.Setup()
+	ctx := cli.NewContext(app, nil, nil)
+	cmd := zsh.NewCommands(config.NewConfig(), []cli.Flag{})
+
+	if cmd.Name != "zsh" {
+		t.Errorf("expected command name to be 'zsh', but got '%s'", cmd.Name)
+	}
+
+	if cmd.Usage != "zsh completion" {
+		t.Errorf("expected command usage to be 'zsh completion', but got '%s'", cmd.Usage)
+	}
+
+	if err := cmd.Run(ctx); err != nil {
+		t.Errorf("falied to run zsh completion: %v\nstdout: %v\n stderr: %v", err, stdout, stderr)
+	}
+
+	if stdout.Len() == 0 {
+		t.Error("expected zsh completion output to be non-empty, but got empty")
+	}
+}


### PR DESCRIPTION
- Add test files for completion commands in `internal/command/completion` directory
- Implement tests for `NewCommands` function in each completion package (`fish`, `zsh`, `bash`, `powershell`)
- Test the correctness of command name, command usage, and output of each completion command
- Verify that the output of each completion command is not empty
