### PR TITLE
feat: Update Gitignores and Makefile for test coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /bin/
 /dist/
 /book/
+cover.html
+cover.out

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,8 @@ lint:
 
 .PHONY: test
 test:
-	CGO_ENABLED=0 go test ./...
+	go test -cover -coverprofile=cover.out ./...
+	go tool cover -html=cover.out -o cover.html
 
 .PHONY: build
 build: bin/$(APPNAME)


### PR DESCRIPTION
- Add `cover.html` and `cover.out` to the `.gitignore` file
- Modify the test command in the Makefile to generate a test coverage report in HTML format
