### PR TITLE
build: Change test and coverage targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ lint:
 
 .PHONY: test
 test:
+	go test ./...
+
+.PHONY: cover
+cover:
 	go test -cover -coverprofile=cover.out ./...
 	go tool cover -html=cover.out -o cover.html
 


### PR DESCRIPTION
- Added `test` and `cover` targets to the `Makefile`
- The `test` target now runs all tests using `go test`
- The `cover` target runs tests with coverage and generates an HTML report
