### PR TITLE
chore: Rename coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /bin/
 /dist/
 /book/
-cover.html
-cover.out
+coverage.html
+coverage.out

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,7 +1,7 @@
 coverage:
   if: true
   paths:
-  - cover.out
+  - coverage.out
 codeToTestRatio:
   code:
   - '**/*.go'

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ lint:
 test:
 	go test ./...
 
-.PHONY: cover
-cover:
-	go test -cover -coverprofile=cover.out ./...
-	go tool cover -html=cover.out -o cover.html
+.PHONY: coverage
+coverage:
+	go test -cover -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html
 	octocov
 
 .PHONY: build


### PR DESCRIPTION
- Update ignored files in `.gitignore`
- Rename `cover` target to `coverage` in Makefile
- Update commands in `coverage` target to use Go's testing tools for coverage reports
- Add `octocov` command to `coverage` target
- Change path from "cover.out" to "coverage.out" in `.octocov.yml`
